### PR TITLE
Propagate bus 'close'

### DIFF
--- a/lib/channel.js
+++ b/lib/channel.js
@@ -14,6 +14,7 @@ function Channel(bus, sourceId, destinationId, namespace, encoding) {
   var self = this;
 
   this.bus.on('message', onmessage);
+  this.bus.on('close', self.close);
   this.once('close', onclose);
 
   function onmessage(sourceId, destinationId, namespace, data) {


### PR DESCRIPTION
This may be related to the other 2 pending PRs, but seems to be clean and to make sense on all levels - and most importantly, address the root of the issue.

Here's what happens: sometimes, the connection closes. The lib/client Client instance would handle it properly, calling it's onclose, which nulls .ps.

Then all sorts of hell would break loose as various things would try to call castv2 methods, but .ps is null.

The solution - propagate the close up the chain, so that whoever uses castv2 and castv2-client will know the connection has closed and handle it properly.
